### PR TITLE
add browsershot 4.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "backpack/crud": "^5.0|^6.0",
-        "spatie/browsershot": "^3.41"
+        "spatie/browsershot": "^3.41|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.0",

--- a/config/download.php
+++ b/config/download.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+    // the view to build the pdf from
+    'view' => 'crud::show',
+    // when using the default view `crud::show` you can define the content class to be used
+    'contentClass' => 'col-md-12',
+
+    
+    // the format used to build the pdf. when `browsershot` config is used this is ignored and you should define the format yourself.
+    'format' => 'A4',
+    // the headers to send with the pdf download response
+    'headers' => ['Content-Type' => 'application/pdf'],
+
+    
+
+    // an invokable class that build the Browsershot instance with custom settings like node path, headless, etc.
+    // the class should have a `__invoke` method that accept an array of data and return the Browsershot result.
+    // check docs at: https://github.com/Laravel-Backpack/download-operation?tab=readme-ov-file#configure-the-browsershot-instance
+    'browsershot' => null,
+];

--- a/src/AddonServiceProvider.php
+++ b/src/AddonServiceProvider.php
@@ -57,7 +57,7 @@ class AddonServiceProvider extends ServiceProvider
     public function register(): void
     {
         if ($this->packageDirectoryExistsAndIsNotEmpty('config')) {
-            $this->mergeConfigFrom($this->path.'/config/downloadoperation.php', 'backpack.downloadoperation');
+            $this->mergeConfigFrom($this->path.'/config/download.php', 'backpack.operations.download');
         }
     }
 
@@ -71,7 +71,7 @@ class AddonServiceProvider extends ServiceProvider
         // Publishing the configuration file.
         if ($this->packageDirectoryExistsAndIsNotEmpty('config')) {
             $this->publishes([
-                $this->path.'/config/downloadoperation.php' => config_path('backpack/downloadoperation.php'),
+                $this->path.'/config/download.php' => config_path('backpack/operations/download.php'),
             ], 'config');
         }
 

--- a/src/DownloadOperation.php
+++ b/src/DownloadOperation.php
@@ -33,19 +33,6 @@ trait DownloadOperation
 
         $this->crud->operation('download', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
-
-            // if no default setting have been registered using config file
-            // or therwise, then use some generics
-            if (!$this->crud->get('download.view')) {
-                $this->crud->set('download.view', 'crud::show');
-                $this->crud->set('show.contentClass', 'col-md-12');
-            }
-            if (!$this->crud->get('download.format')) {
-                $this->crud->set('download.format', 'A4');
-            }
-            if (!$this->crud->get('download.headers')) {
-                $this->crud->set('download.headers', ['Content-Type' => 'application/pdf']);
-            }
         });
 
         $this->crud->operation(['list', 'show'], function () {
@@ -58,7 +45,7 @@ trait DownloadOperation
      *
      * @return Response
      */
-    public function download()
+    public function download($id = null)
     {
         $this->crud->hasAccessOrFail('download');
 
@@ -72,7 +59,8 @@ trait DownloadOperation
         $data['format'] = $this->crud->get('download.format');
         $data['view'] = $this->crud->get('download.view');
         $data['headers'] = $this->crud->get('download.headers');
-
+        $data['browsershot'] = $this->crud->get('download.browsershot');
+        
         return $this->downloadFile($data);
     }
 
@@ -86,6 +74,11 @@ trait DownloadOperation
     protected function downloadFile($data)
     {
         return response()->streamDownload(function () use ($data) {
+            if ($data['browsershot']) {
+                echo (new $data['browsershot'])($data);
+                return;
+            }
+
             echo Browsershot::html(view($data['view'], $data))
                 ->format($data['format'])
                 ->pdf();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in #8 our browsershot version it quite outdated and locked into v3.

### AFTER - What is happening after this PR?

This allow v4 to be installed.
